### PR TITLE
feat: Enhance GitHub agent with action-specific tool registration

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,6 +65,7 @@ def main():
         openai_api_key=openai_api_key,
         model=os.environ.get("MODEL", "gpt-4o-mini"),
         custom_prompt=os.environ.get("CUSTOM_PROMPT"),
+        action_type=action_type,
     )
 
     # Run appropriate action based on action_type


### PR DESCRIPTION
- Add `action_type` parameter to GitHubAgent initialization
- Implement dynamic tool registration based on action type
- Support PR review and issue analysis action-specific tools
- Conditionally register PR approval tool based on AUTO_APPROVE environment variable